### PR TITLE
several cross-platform and packaging fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,9 +108,7 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
     FreeConsole();
     QFile LogFile("emu64.log");
-#endif
-
-#ifdef __linux__
+#else
     if(!config_dir.exists())
     {
         QDir dir = QDir::root();
@@ -132,10 +130,16 @@ int main(int argc, char *argv[])
 
 #ifdef _WIN32
     if(log) *log << "*** Emu64 Win32 Binary File ***\n\n";
-#endif
-
-#ifdef __linux__
+#else
+# ifdef __linux__
     if(log) *log << "*** Emu64 Linux Binary File ***\n\n";
+# else
+#  ifdef __FreeBSD__
+    if(log) *log << "*** Emu64 FreeBSD Binary File ***\n\n";
+#  else
+    if(log) *log << "*** Emu64 POSIX (unknown) Binary File ***\n\n";
+#  endif
+# endif
 #endif
 
     if(log != nullptr) *log << "Emu64 Version: " << VERSION_STRING << "\n\n";

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -41,10 +41,16 @@ MainWindow::MainWindow(QWidget *parent,CustomSplashScreen* splash,QTextStream *l
 
 #ifdef _WIN32
     setWindowTitle("Emu64 Version " + QString(VERSION_STRING) + " --- [Windows " + QString(ARCHITECTURE_STRING) + "]");
-#endif
-
-#ifdef __linux__
+#else
+# ifdef __linux__
     setWindowTitle("Emu64 Version " + QString(VERSION_STRING) + " --- [Linux " + QString(ARCHITECTURE_STRING) + "]");
+# else
+#  ifdef __FreeBSD__
+    setWindowTitle("Emu64 Version " + QString(VERSION_STRING) + " --- [FreeBSD " + QString(ARCHITECTURE_STRING) + "]");
+#  else
+    setWindowTitle("Emu64 Version " + QString(VERSION_STRING) + " --- [POSIX (unknown) " + QString(ARCHITECTURE_STRING) + "]");
+#  endif
+# endif
 #endif
 }
 
@@ -158,8 +164,7 @@ void MainWindow::OnInit()
         dataPath = QApplication::applicationDirPath();
     else
         dataPath = custom_dataPath;
-#endif
-#ifdef __linux__
+#else
     if(custom_dataPath == "")
     {
         dataPath = DATA_PATH;

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,34 +24,39 @@ QT += widgets
 TARGET = emu64
 TEMPLATE = app
 
-CONFIG += c++11
+CONFIG += lrelease c++11
+
+EMU64_VERSION = 5.0.17
 
 # Versionsnummer ermitteln aus Git Tag Nummer
 GIT_VERSION = $$system(git --git-dir \"../.git\" describe --always --tags)
+isEmpty(GIT_VERSION) {
+  GIT_VERSION = $$EMU64_VERSION
+}
 DEFINES += VERSION_STRING=\\\"$$GIT_VERSION\\\"
 
 message("Emu64 Version: " $$GIT_VERSION)
 
-# Linux Architecture
-linux-g++{
-   !contains(QT_ARCH, x86_64){
-       DEFINES += ARCHITECTURE_STRING=\\\"32Bit\\\"
-       message("Compiling for Linux 32bit system")
-    } else {
-       DEFINES += ARCHITECTURE_STRING=\\\"64Bit\\\"
-       message("Compiling for Linux 64bit system")
-   }
+contains(QT_ARCH, x86_64){
+    EMU64_ARCH = 64Bit
+} else:contains(QT_ARCH, i[3456]86) {
+    EMU64_ARCH = 32Bit
+} else {
+    EMU64_ARCH = Unknown
 }
 
-# Windows Architecture
-win32{
-   !contains(QT_ARCH, x86_64){
-       DEFINES += ARCHITECTURE_STRING=\\\"32Bit\\\"
-       message("Compiling for Windows 32bit system")
-    } else {
-       DEFINES += ARCHITECTURE_STRING=\\\"64Bit\\\"
-       message("Compiling for Windows 64bit system")
-   }
+DEFINES += ARCHITECTURE_STRING=\\\"$$EMU64_ARCH\\\"
+
+win32 {
+    message("Compiling for Windows $$EMU64_ARCH system")
+} else:linux {
+    message("Compiling for Linux $$EMU64_ARCH system")
+} else:freebsd {
+    message("Compiling for FreeBSD $$EMU64_ARCH system")
+} else:unix {
+    message("Compiling for Unix $$EMU64_ARCH system")
+} else {
+    message("Compiling for Unknown $$EMU64_ARCH system")
 }
 
 # Abhängigkeiten
@@ -64,14 +69,11 @@ PKGCONFIG += sdl2 SDL2_image libpng glu libavutil libavformat libavcodec libswre
 
 message("Zip: $$ZIP")
 
-linux-g++{
-    DEFINES += ZIP_SUPPORT=true
-    LIBS += -lquazip5
-}
-
-win32{
-    DEFINES += ZIP_SUPPORT=true
+DEFINES += ZIP_SUPPORT=true
+win32 {
     PKGCONFIG += quazip
+} else {
+    LIBS += -lquazip5
 }
 
 # Quelltexte
@@ -230,16 +232,14 @@ RC_FILE += emu64.rc
 message(Installpath: $$PREFIX)
 DEFINES += DATA_PATH=\\\"$$PREFIX\\\"
 
-win32{
+win32 {
     target.path = $$PREFIX
     roms.path = $$PREFIX/roms
     floppy_sounds.path = $$PREFIX/floppy_sounds
     gfx.path = $$PREFIX/gfx
     txt.path = $$PREFIX
     languages.path = $$PREFIX/languages
-}
-
-linux-g++{
+} else {
     target.path = $$PREFIX/bin
     roms.path = $$PREFIX/share/$$TARGET/roms
     floppy_sounds.path = $$PREFIX/share/$$TARGET/floppy_sounds

--- a/src/src.pro
+++ b/src/src.pro
@@ -13,7 +13,7 @@
 # //                                              //
 # //////////////////////////////////////////////////
 
-# PREFIX=/usr/local
+!win32:isEmpty(PREFIX):PREFIX=/usr/local
 
 QT       += core gui
 
@@ -244,7 +244,7 @@ win32 {
     roms.path = $$PREFIX/share/$$TARGET/roms
     floppy_sounds.path = $$PREFIX/share/$$TARGET/floppy_sounds
     gfx.path = $$PREFIX/share/$$TARGET/gfx
-    txt.path = $$PREFIX/share/$$TARGET
+    txt.path = $$PREFIX/share/doc/$$TARGET
     languages.path = $$PREFIX/share/$$TARGET/languages
 }
 
@@ -269,8 +269,8 @@ txt.files += ../änderungen.txt
 # Languages
 languages.files += ../grafik/flaggen/emu64_de.png
 languages.files += ../grafik/flaggen/emu64_en.png
-languages.files += emu64_de.qm
-languages.files += emu64_en.qm
+languages.extra += $(INSTALL_FILE) .qm/emu64_de.qm $(INSTALL_ROOT)$$languages.path;
+languages.extra += $(INSTALL_FILE) .qm/emu64_en.qm $(INSTALL_ROOT)$$languages.path;
 
 INSTALLS += target roms floppy_sounds gfx txt languages
 }


### PR DESCRIPTION
  * add "lrelease" to src.pro CONFIG, so it doesn't have to be invoked
    manually, helping packagers to use their standard qmake-based rules
  * add hardcoded version string to src.pro which is used when building from
    a release archive instead of a git repo (which is normal when building
    packages)
  * add fallbacks for unknown operating systems and processor
    architectures, assume unknown operating systems are POSIX compliant
  * add explicit support for FreeBSD