### PR TITLE
Move SingleApplication from sharedmemory to socket

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 
 #include "./custom_splashscreen.h"
 #include <QBitmap>
-#include <QTimer>
 
 #include "./command_line_class.h"   // Klasse zur Auswertung der KomandLine
 #include "./emu64_commands.h"       // Struktur mit allen verfügbaren Kommandos
@@ -34,6 +33,10 @@ int main(int argc, char *argv[])
 #if (!defined(SINGLE_THREADED_PLAYBACK) and defined(Q_WS_X11))
     XInitThreads();
 #endif
+
+    QCoreApplication::setOrganizationName("ThKattanek");
+    QCoreApplication::setApplicationName("Emu64");
+    QCoreApplication::setApplicationVersion(VERSION_STRING);
 
     QTextStream *log = nullptr;
     QDir config_dir = QDir(QDir::homePath() + "/.config/emu64");
@@ -88,7 +91,7 @@ int main(int argc, char *argv[])
     }
 
     SingleApplication *app;
-    app = new SingleApplication (argc, argv,  "Emu64_By_Thorsten_Kattanek");
+    app = new SingleApplication (argc, argv);
 
     bool isFirstInstance;
 
@@ -96,7 +99,9 @@ int main(int argc, char *argv[])
     {
         if (app->alreadyExists())
         {
-            for(int i=0;i<argc;i++) app->sendMessage(argv[i]);
+	    QStringList args;
+            for(int i=0;i<argc;i++) args << argv[i];
+	    app->sendMessages(args);
             isFirstInstance = false;
             return 0;
         }
@@ -203,12 +208,11 @@ int main(int argc, char *argv[])
         ret = app->exec();
     }
 
-    app->deleteSharedMemory();
-
     if(w->IsLimitCyclesEvent) ret = 1;
     if(w->IsDebugCartEvent) ret = w->DebugCartValue;
 
     delete w;
+    delete app;
 
     cout << "ExitCode: 0x" << std::hex << ret << endl;
     return ret;

--- a/src/single_application.h
+++ b/src/single_application.h
@@ -16,18 +16,16 @@
 #ifndef SINGLE_APPLICATION_H
 #define SINGLE_APPLICATION_H
 
-//#include <QApplication>
-#include <qapplication.h>
-#include <QSharedMemory>
-#include <QStringList>
+#include <QApplication>
+#include <QLocalServer>
+#include <QSet>
+#include <QString>
 
 class SingleApplication : public QApplication
 {
         Q_OBJECT
 public:
-        SingleApplication(int &argc, char *argv[], const QString uniqueKey);
-
-        void deleteSharedMemory();
+        SingleApplication(int &argc, char *argv[]);
 
         bool alreadyExists() const{
             return bAlreadyExists;
@@ -36,16 +34,16 @@ public:
             return !alreadyExists();
         }
 
-        bool sendMessage(const QString &message);
-
-public slots:
-        void checkForMessage();
+        bool sendMessages(const QStringList &messages);
 
 signals:
         void messageAvailable(const QStringList& messages);
+	void remoteActivated();
 
 private:
+	QString instanceServerName;
+	QLocalServer instanceServer;
+	QSet<QLocalSocket *> activeClients;
         bool bAlreadyExists;
-        QSharedMemory *sharedMemory;
 };
 #endif // SINGLE_APPLICATION_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -15,7 +15,7 @@
 
 !win32:isEmpty(PREFIX):PREFIX=/usr/local
 
-QT       += core gui
+QT       += core gui network
 
 greaterThan(QT_MAJOR_VERSION, 4){
 


### PR DESCRIPTION
* Add current username to unique id, so multiple users can use emu64 at
  the same time
* Robust handling of previously crashed processes (Windows and POSIX)
* Provide new signal for any remote activity (e.g. to bring window to
  front)
* Explicitly allow "main instance" to bring window to front on Windows

Wie angekündigt hier mein Vorschlag für single application. Der Change ist relativ invasiv, muss also gut getestet werden. Ich habe bisher nur einen kleinen Test auf FreeBSD vorgenommen, prinzipiell funktioniert es -- nach Start der ersten Instanz:

    $ sockstat -l | grep emu64
    felix    emu64      7574  12 stream /tmp/B2GkYu79NvJ8_VXrMafXxj5OYEik8MSGsqpOzgMg32I=

Danach klappt z.B. ein `src/emu64 --poke64 53280 0` :)

Wenn es auf FreeBSD korrekt funktioniert ist es fast sicher, dass das auch auf Linux der Fall ist. Wichtig wäre ein Test auf Windows -- der Code ist größtenteils aus einem eigenen Projekt portiert, und funktioniert dort auch absolut problemlos auf Windows, allerdings bin ich mir nicht ganz sicher, wie ich emu64 mit meinem MXE bauen kann, daher habe ich es hier noch nicht getestet.

Zur genauen Funktionsweise sind ein paar Kommentare drin, ich hoffe die sind so "ausreichend" :)

Grüße
Felix