### PR TITLE
Fix type in libpng callback

### DIFF
--- a/src/savepng.c
+++ b/src/savepng.c
@@ -25,7 +25,7 @@
 #endif
 
 /* libpng callbacks */ 
-static void png_error_SDL(png_structp *png_ptr, png_const_charp str)
+static void png_error_SDL(png_structp png_ptr, png_const_charp str)
 {
 	SDL_SetError("libpng: %s\n", str);
 }


### PR DESCRIPTION
This is entirely irrelevant for functionality as the argument isn't used, but the wrong type is now considered a hard error by LLVM clang 16, breaking the build.