### PR TITLE
Fix quazip dependency for FreeBSD

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -90,6 +90,8 @@ equals(QT_MAJOR_VERSION, 5) {
 
     win32 {
         PKGCONFIG += quazip
+    } else:freebsd {
+        PKGCONFIG += quazip1-qt5
     } else {
         LIBS += -lquazip5
     }

--- a/src/widget_file_browse.h
+++ b/src/widget_file_browse.h
@@ -22,7 +22,7 @@
 #include <QRegExp>
 
 #ifdef ZIP_SUPPORT
-#ifdef __WIN32      // MXE
+#if defined(__WIN32) || defined(__FreeBSD__)
         #include "quazip/quazip.h"
         #include "quazip/quazipfile.h"
 #else


### PR DESCRIPTION
Forgot to suggest that earlier, it will enable building on FreeBSD without the need for any patches ...