### PR TITLE
CI: Build with both gcc and clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      CI_CXXFLAGS: -O2 -Wall -Wextra -Wshadow=local -Werror -pedantic
+      CI_CXXFLAGS: -O2 -Wall -Wextra -Werror -pedantic
+      WSHADOW_GCC: -Wshadow=local
+      WSHADOW_CLANG: -Wshadow-uncaptured-local
     steps:
     - uses: actions/checkout@v3
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: |
+          clang
           libavcodec-dev
           libavformat-dev
           libavutil-dev
@@ -28,9 +31,17 @@ jobs:
           qtbase5-dev
           qttools5-dev-tools
         version: 1.0
-    - name: make
+    - name: build-gcc
       run: |
-        mkdir build
-        cd build
-        qmake .. PREFIX="/usr/local" QMAKE_CXXFLAGS="${CI_CXXFLAGS}"
+        mkdir build-gcc
+        cd build-gcc
+        qmake .. PREFIX=/usr/local QMAKE_CXX=g++ \
+                 QMAKE_CXXFLAGS="${CI_CXXFLAGS} ${WSHADOW_GCC}"
+        make -j4
+    - name: build-clang
+      run: |
+        mkdir build-clang
+        cd build-clang
+        qmake .. PREFIX=/usr/local QMAKE_CXX=clang++ \
+                 QMAKE_CXXFLAGS="${CI_CXXFLAGS} ${WSHADOW_CLANG}"
         make -j4

--- a/src/c64_class.cpp
+++ b/src/c64_class.cpp
@@ -1489,7 +1489,6 @@ void C64Class::SetGrafikModi(bool enable_screen_doublesize, bool enable_screen_c
     this->enable_screen_doublesize = enable_screen_doublesize;
     this->enable_screen_crt_output =  enable_screen_crt_output;
     this->enable_screen_filter = enable_screen_filter;
-    this->start_minimized = start_minimized;
     this->fullscreen_width = fullscreen_width;
     this->fullscreen_height = fullscreen_height;
 

--- a/src/floppy1541_class.cpp
+++ b/src/floppy1541_class.cpp
@@ -136,7 +136,7 @@ Floppy1541::~Floppy1541()
 
     FloppySoundEnabled = false;
     FloppyEnabled = false;
-    delete SoundBuffer;
+    delete[] SoundBuffer;
     delete cpu;
     delete via1;
     delete via2;

--- a/src/floppy1541_class.h
+++ b/src/floppy1541_class.h
@@ -136,8 +136,6 @@ private:
     int     DiskChangeSimState;         // 0 = momentan kein Diskwechsel
     int     DiskChangeSimCycleCounter;
 
-    REG_STRUCT rs;
-
     std::function<uint8_t(uint16_t)>  ReadProcTbl[256];
     std::function<void(uint16_t, uint8_t)> WriteProcTbl[256];
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -365,7 +365,7 @@ int MainWindow::OnInit(bool nogui)
 
     SplashMessage(tr("C64 Klasse wird initialisiert."),Qt::darkBlue);
     int ret_error;
-    c64 = new C64Class(&ret_error ,soundbuffer_size ,video_crt_output,start_minimized, bind(&MainWindow::LogText,this,std::placeholders::_1),QString(dataPath).toLocal8Bit());
+    c64 = new C64Class(&ret_error ,soundbuffer_size ,video_crt_output,start_minimized, std::bind(&MainWindow::LogText,this,std::placeholders::_1),QString(dataPath).toLocal8Bit());
     if(ret_error != 0)
     {
         LogText(tr("<< Fehler beim initiallisieren der C64 Klasse.\n").toUtf8());
@@ -462,7 +462,7 @@ int MainWindow::OnInit(bool nogui)
 
     /// CRT LED mit CRT_Window verbinden ///
     SplashMessage(tr("CRT LED mit CRT Window verbunden."),Qt::darkBlue);
-    c64->crt->ChangeLED = bind(&CartridgeWindow::ChangeLED,cartridge_window,std::placeholders::_1,std::placeholders::_2);
+    c64->crt->ChangeLED = std::bind(&CartridgeWindow::ChangeLED,cartridge_window,std::placeholders::_1,std::placeholders::_2);
     LogText(tr(">> CRT LED wurde mit CrtWindow verbunden\n").toUtf8());
 
     /// C64 Systemroms laden ///

--- a/src/mmu_class.cpp
+++ b/src/mmu_class.cpp
@@ -189,9 +189,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_BASIC_ROM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
@@ -200,7 +200,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -217,9 +217,9 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -228,7 +228,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -248,32 +248,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_BASIC_ROM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -283,9 +283,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadCRT1,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadCRT1,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_CRT_1;
                                 MapReadSource[0xA0+i] = MV_BASIC_ROM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
@@ -294,7 +294,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -311,9 +311,9 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_CRT_1;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -322,7 +322,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -342,32 +342,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadCRT1,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadCRT1,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadBasicRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_CRT_1;
                                 MapReadSource[0xA0+i] = MV_BASIC_ROM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_CRT_1;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -377,9 +377,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadCRT1,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadCRT2,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadCRT1,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadCRT2,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_CRT_1;
                                 MapReadSource[0xA0+i] = MV_CRT_2;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
@@ -388,7 +388,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -405,9 +405,9 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_CRT_1;
                                 MapWriteDestination[0xA0+i] = MV_CRT_2;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -416,7 +416,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -436,32 +436,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadCRT1,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadCRT2,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadCRT1,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadCRT2,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_CRT_1;
                                 MapReadSource[0xA0+i] = MV_CRT_2;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_CRT_1;
                                 MapWriteDestination[0xA0+i] = MV_CRT_2;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -471,9 +471,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadCRT2,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadCRT2,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_CRT_2;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
@@ -482,7 +482,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -499,9 +499,9 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_CRT_2;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -510,7 +510,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -530,16 +530,16 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadCRT2,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadCRT2,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_CRT_2;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
@@ -547,16 +547,16 @@ void MMU::ChangeMemMap()
 
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteCRT2,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_CRT_2;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -566,9 +566,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_RAM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
@@ -577,7 +577,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -594,9 +594,9 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -605,7 +605,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -625,32 +625,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadKernalRom,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_RAM;
                                 MapReadSource[0xE0+i] = MV_KERNAL_ROM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -660,9 +660,9 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_RAM;
                                 MapReadSource[0xE0+i] = MV_RAM;
@@ -671,7 +671,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -687,9 +687,9 @@ void MMU::ChangeMemMap()
 
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
@@ -698,7 +698,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -718,32 +718,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_RAM;
                                 MapReadSource[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadCharRom,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadCharRom,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_CHAR_ROM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -753,32 +753,32 @@ void MMU::ChangeMemMap()
 			/// READ
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_RAM;
                                 MapReadSource[0xA0+i] = MV_RAM;
                                 MapReadSource[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUReadProcTbl[0xD0+i] = bind(&MMU::ReadRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD0+i] = std::bind(&MMU::ReadRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_RAM;
 			}
 
 			/// WRITE
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_RAM;
                                 MapWriteDestination[0xA0+i] = MV_RAM;
                                 MapWriteDestination[0xE0+i] = MV_RAM;
 			}
 			for(int i=0;i<16;++i)
 			{
-                                CPUWriteProcTbl[0xD0+i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD0+i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_RAM;
 			}
 		}break;
@@ -789,19 +789,19 @@ void MMU::ChangeMemMap()
 			/// READ
                         for(int i=0;i<112;i++)
                         {
-                            CPUReadProcTbl[0x10+i] = bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
+                            CPUReadProcTbl[0x10+i] = std::bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
                             MapReadSource[0x10+i] = MV_OPEN;
                         }
                         for(int i=0;i<16;i++)
                         {
-                            CPUReadProcTbl[0xC0+i] = bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
+                            CPUReadProcTbl[0xC0+i] = std::bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
                             MapReadSource[0xC0+i] = MV_OPEN;
                         }
 			for(int i=0;i<32;++i)
 			{
-                                CPUReadProcTbl[0x80+i] = bind(&MMU::ReadCRT1,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xA0+i] = bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
-                                CPUReadProcTbl[0xE0+i] = bind(&MMU::ReadCRT3,this,std::placeholders::_1);
+                                CPUReadProcTbl[0x80+i] = std::bind(&MMU::ReadCRT1,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xA0+i] = std::bind(&MMU::ReadOpenAdress,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xE0+i] = std::bind(&MMU::ReadCRT3,this,std::placeholders::_1);
                                 MapReadSource[0x80+i] = MV_CRT_1;
                                 MapReadSource[0xA0+i] = MV_OPEN;
                                 MapReadSource[0xE0+i] = MV_CRT_3;
@@ -810,7 +810,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUReadProcTbl[0xD0+i] = VicIOReadProc;
                                 CPUReadProcTbl[0xD4+i] = SidIOReadProc;
-                                CPUReadProcTbl[0xD8+i] = bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
+                                CPUReadProcTbl[0xD8+i] = std::bind(&MMU::ReadFarbRam,this,std::placeholders::_1);
                                 MapReadSource[0xD0+i] = MV_VIC;
                                 MapReadSource[0xD4+i] = MV_SID;
                                 MapReadSource[0xD8+i] = MV_FARB_RAM;
@@ -827,19 +827,19 @@ void MMU::ChangeMemMap()
 			/// WRITE
 			for(int i=0;i<112;i++)
 			{
-                                CPUWriteProcTbl[0x10+i] = bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x10+i] = std::bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x10+i] = MV_OPEN;
 			}
 			for(int i=0;i<16;i++)
 			{
-                                CPUWriteProcTbl[0xC0+i] = bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xC0+i] = std::bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xC0+i] = MV_OPEN;
 			}
 			for(int i=0;i<32;++i)
 			{
-                                CPUWriteProcTbl[0x80+i] = bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xA0+i] = bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
-                                CPUWriteProcTbl[0xE0+i] = bind(&MMU::WriteCRT3,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0x80+i] = std::bind(&MMU::WriteCRT1,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xA0+i] = std::bind(&MMU::WriteOpenAdress,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xE0+i] = std::bind(&MMU::WriteCRT3,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0x80+i] = MV_CRT_1;
                                 MapWriteDestination[0xA0+i] = MV_OPEN;
                                 MapWriteDestination[0xE0+i] = MV_CRT_3;
@@ -848,7 +848,7 @@ void MMU::ChangeMemMap()
 			{
                                 CPUWriteProcTbl[0xD0+i] = VicIOWriteProc;
                                 CPUWriteProcTbl[0xD4+i] = SidIOWriteProc;
-                                CPUWriteProcTbl[0xD8+i] = bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
+                                CPUWriteProcTbl[0xD8+i] = std::bind(&MMU::WriteFarbRam,this,std::placeholders::_1,std::placeholders::_2);
                                 MapWriteDestination[0xD0+i] = MV_VIC;
                                 MapWriteDestination[0xD4+i] = MV_SID;
                                 MapWriteDestination[0xD8+i] = MV_FARB_RAM;
@@ -870,21 +870,21 @@ inline void MMU::InitProcTables(void)
 {
 	for(int i=0;i<256;++i)
 	{
-                CPUReadProcTbl[i] =  bind(&MMU::ReadRam,this,std::placeholders::_1);
-                CPUWriteProcTbl[i] = bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
-                VICReadProcTbl[i] = bind(&MMU::ReadVicRam,this,std::placeholders::_1);
+                CPUReadProcTbl[i] =  std::bind(&MMU::ReadRam,this,std::placeholders::_1);
+                CPUWriteProcTbl[i] = std::bind(&MMU::WriteRam,this,std::placeholders::_1,std::placeholders::_2);
+                VICReadProcTbl[i] = std::bind(&MMU::ReadVicRam,this,std::placeholders::_1);
                 MapReadSource[i] = MV_RAM;
                 MapWriteDestination[i] = MV_RAM;
 	}
 
 	for(int i=0;i<16;++i)
 	{
-                VICReadProcTbl[0x10+i] = bind(&MMU::ReadVicCharRomBank0,this,std::placeholders::_1);
-                VICReadProcTbl[0x90+i] = bind(&MMU::ReadVicCharRomBank2,this,std::placeholders::_1);
+                VICReadProcTbl[0x10+i] = std::bind(&MMU::ReadVicCharRomBank0,this,std::placeholders::_1);
+                VICReadProcTbl[0x90+i] = std::bind(&MMU::ReadVicCharRomBank2,this,std::placeholders::_1);
 	}
 
-        CPUReadProcTbl[0] = bind(&MMU::ReadZeroPage,this,std::placeholders::_1);
-        CPUWriteProcTbl[0] = bind(&MMU::WriteZeroPage,this,std::placeholders::_1,std::placeholders::_2);
+        CPUReadProcTbl[0] = std::bind(&MMU::ReadZeroPage,this,std::placeholders::_1);
+        CPUWriteProcTbl[0] = std::bind(&MMU::WriteZeroPage,this,std::placeholders::_1,std::placeholders::_2);
 }
 
 unsigned char MMU::ReadZeroPage(unsigned short adresse)

--- a/src/mos6510_class.cpp
+++ b/src/mos6510_class.cpp
@@ -452,7 +452,7 @@ bool MOS6510::OneZyklus(void)
 
 			CHK_RDY
 
-			if((nmi_is_active == true)) // NMIStatePuffer[CYCLES] --> 2 CYCLES Sagt zwei Zyklen vorher muss der NMI schon angelegen haben also vor dem letzten Zyklus des vorigen Befehls
+			if(nmi_is_active == true) // NMIStatePuffer[CYCLES] --> 2 CYCLES Sagt zwei Zyklen vorher muss der NMI schon angelegen haben also vor dem letzten Zyklus des vorigen Befehls
 			{
 				nmi_is_active = false;
 				MCT = ((unsigned char*)MicroCodeTable6510 + (0x102*MCTItemSize));

--- a/src/mos6581_8085_class.cpp
+++ b/src/mos6581_8085_class.cpp
@@ -89,10 +89,10 @@ MOS6581_8085::MOS6581_8085(int nummer,int samplerate,int puffersize,int *error)
 
 MOS6581_8085::~MOS6581_8085()
 {
-    delete SoundBuffer;
-    delete SoundBufferV0;
-    delete SoundBufferV1;
-    delete SoundBufferV2;
+    delete[] SoundBuffer;
+    delete[] SoundBufferV0;
+    delete[] SoundBufferV1;
+    delete[] SoundBufferV2;
 
     delete IoDump;
 
@@ -103,10 +103,10 @@ MOS6581_8085::~MOS6581_8085()
 
 void MOS6581_8085::ChangeSampleRate(int samplerate,int puffersize)
 {
-    delete SoundBuffer;
-    delete SoundBufferV0;
-    delete SoundBufferV1;
-    delete SoundBufferV2;
+    delete[] SoundBuffer;
+    delete[] SoundBufferV0;
+    delete[] SoundBufferV1;
+    delete[] SoundBufferV2;
 
     Samplerate=samplerate;
     FreqConvAddWert=1.0f/(C64ZyklenSek/Samplerate);

--- a/src/tape1530_class.h
+++ b/src/tape1530_class.h
@@ -90,7 +90,6 @@ private:
 
     unsigned int	ZyklenCounter;
     unsigned int	WaitCounter;
-    unsigned int    WaitCounterHalf;
 
     float           Counter;
     float Time2CounterTbl[1800];    // Platz für 1800 sek (30min)
@@ -118,7 +117,6 @@ private:
     signed short	*SoundBuffer;
     unsigned int	SoundBufferPos;
     unsigned int	SoundBufferSize;
-    bool			SoundOutputEnable;
     float           Volume;
 
     float PlayFrequenzFaktor;


### PR DESCRIPTION
After all the latest fixes, I was surprised emu64 didn't build any more locally on FreeBSD using clang, even without `-Werror`. The immediate cause were some unscoped `bind()` (`std::` missing) calls that *somehow* seem to still resolve on Linux. But it also showed clang had some warnings that gcc didn't find.

So, to avoid as many issues as possible, I think it is best to test the build with *both* major compilers, gcc and clang. Of course this means CI builds take twice the time.

The PR includes fixes for the issues found by clang warnings.